### PR TITLE
Refactor input handling in typed procedures 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ async function main() {
     apiKey: process.env.WARERA_API_KEY
   });
 
-  const allCountries = await client.country.getAllCountries({});
+  const allCountries = await client.country.getAllCountries();
   const firstId = allCountries[0]._id;
 
   // Multiple calls in the same tick can be batched into fewer HTTP requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "warera-trpc-client",
-	"version": "0.1.0",
+	"name": "@wareraprojects/api",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "warera-trpc-client",
-			"version": "0.1.0",
+			"name": "@wareraprojects/api",
+			"version": "0.1.3",
 			"license": "MIT",
 			"dependencies": {
 				"@trpc/client": "^10.45.2",


### PR DESCRIPTION
Fix auto-pagination type detection to prevent unintended fallback to AsyncIterableIterator

# Problem
The `getCompanies()` endpoint, and alike, was being treated as if it defaulted to returning an `AsyncIterableIterator` when called without arguments, instead of returning `Promise<CompanyGetCompaniesResponse>`. This was because:

The type system was detecting pagination support based on response shape (any response with `items` and `nextCursor`)
Function overload ordering placed the auto-pagination overload before the regular Promise overload, causing TypeScript to prefer it as the default.

# Root Cause
`IsPaginatedResponse` was checking if the response had `items` and `nextCursor` properties
`company.getCompanies()` has that response shape, so it was incorrectly flagged as auto-paginating
Overload order in `ProcedureFunction` type put `AsyncIterableIterator` first, making it the implicit default

# Solution
Updated `typed-procedures.ts` with two key changes:

**Auto-detection logic:** Changed pagination detection from response shape to input shape by checking if the procedure's input accepts an optional `cursor` parameter:

```TypeScript
type IsPaginatedResponse<K extends ProcedureKey> = BaseInputFor<K> extends { cursor?: any }
  ? true
  : false;
```

**Overload ordering:** Reordered function overloads so `Promise<ResponseFor<K>>` comes first, making it the implicit default:

```TypeScript
{
  (input?: InputFor<K>): Promise<ResponseFor<K>>;
  (input?: InputFor<K> & { autoPaginate: true }): AsyncIterableIterator<PageResult<K>>;
}
```

# Impact
✅ `trpc.company.getCompanies()` now correctly returns `Promise<CompanyGetCompaniesResponse>`
✅ Auto-pagination only triggers when explicitly passing `{ autoPaginate: true }`
✅ Auto-detection is now maintainable and extensible - automatically works for any endpoint that accepts a `cursor` parameter
✅ No more manual list maintenance of paginated endpoints
