### PR TITLE
Update function names and export response types.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
+export * from './api/Responses';
 export type { components, operations, paths } from "./api/warera-openapi";
 export {
-    createTrpcClient as createAPIClient,
+    createAPIClient,
     /**
      * @deprecated Use createAPIClient instead
      */
-    createTrpcClient as createTrpcLikeClient
+    createAPIClient as createTrpcLikeClient
 } from "./trpc-client";
 export type {
     TrpcLikeClientOptions as APIClientOptions,
@@ -13,5 +14,5 @@ export type {
      */
     TrpcLikeClientOptions
 } from "./trpc-client";
-export type { InputFor, ProcedureKey, ResponseFor, TrpcLikeClient, PaginationOptions, PageResult } from "./typed-procedures";
+export type { APIClient, InputFor, PageResult, PaginationOptions, ProcedureKey, ResponseFor } from "./typed-procedures";
 

--- a/src/trpc-client.ts
+++ b/src/trpc-client.ts
@@ -1,5 +1,5 @@
 import { createTRPCUntypedClient, httpBatchLink, loggerLink } from "@trpc/client";
-import type { PageResult, ProcedureKey, TrpcLikeClient } from "./typed-procedures";
+import type { APIClient, PageResult, ProcedureKey } from "./typed-procedures";
 
 export interface TrpcLikeClientOptions {
   url?: string;
@@ -242,7 +242,7 @@ function createBatchLoggingFetch(
  * invocation to call remote procedures. For example:
  *
  * ```ts
- * const client = createTrpcClient({ url: 'https://api.example' });
+ * const client = createAPIClient({ url: 'https://api.example' });
  * const result = await client.article.getById({ id: 1 });
  * ```
  *
@@ -260,7 +260,7 @@ function createBatchLoggingFetch(
  * @param options.batchIntervalMs - Time window to batch operations before sending.
  * @returns A `TrpcLikeClient` proxy which can be invoked like `client.foo.bar(input)`
  */
-export function createTrpcClient(options?: TrpcLikeClientOptions & {rateLimit?: number}): TrpcLikeClient {
+export function createAPIClient(options?: TrpcLikeClientOptions & {rateLimit?: number}): APIClient {
   const appliedRateLimit = options?.rateLimit ?? (options?.apiKey !== undefined ? 200 : 100);
   const baseFetch = options?.fetch ?? (globalThis as any).fetch;
   const loggedFetch = createBatchLoggingFetch(baseFetch, options?.logBatches);
@@ -308,5 +308,5 @@ export function createTrpcClient(options?: TrpcLikeClientOptions & {rateLimit?: 
       }
     });
 
-  return makeProxy([]) as TrpcLikeClient;
+  return makeProxy([]) as APIClient;
 }

--- a/src/typed-procedures.ts
+++ b/src/typed-procedures.ts
@@ -116,7 +116,7 @@ type TreeFromKeys<Keys extends string> = UnionToIntersection<
     : never
 >;
 
-export type TrpcLikeClient = MergeDeep<TreeFromKeys<Extract<ProcedureKey, string>>>;
+export type APIClient = MergeDeep<TreeFromKeys<Extract<ProcedureKey, string>>>;
 
 export function procedure<K extends ProcedureKey>(key: K): TrpcProcedure<K> {
   return { key };

--- a/tests/test-api.ts
+++ b/tests/test-api.ts
@@ -1,6 +1,6 @@
-import { createTrpcClient } from "../src/trpc-client";
+import { createAPIClient } from "../src/index";
 
-async function processCountries(allCountries: { _id: string; name: string }[], client: ReturnType<typeof createTrpcClient>): Promise<{ totalUsers: number; totalCompanies: number }> {
+async function processCountries(allCountries: { _id: string; name: string }[], client: ReturnType<typeof createAPIClient>): Promise<{ totalUsers: number; totalCompanies: number }> {
   let totalUsers = 0;
   let totalCompanies = 0;
 
@@ -41,7 +41,7 @@ async function processCountries(allCountries: { _id: string; name: string }[], c
   return { totalUsers, totalCompanies };
 }
 
-async function getAllFromCountry(countryID: string, client: ReturnType<typeof createTrpcClient>) {
+async function getAllFromCountry(countryID: string, client: ReturnType<typeof createAPIClient>) {
   let allUserPromises = [];
 
   // Get all the user IDs from the country using pagination
@@ -66,7 +66,7 @@ async function main() {
   let countingBatches = 0;
   let lastBatchTime = Date.now();
 
-  const client = createTrpcClient({
+  const client = createAPIClient({
     apiKey: process.env.WARERA_API_KEY,
     logBatches: (info) => {
       const now = Date.now();


### PR DESCRIPTION
Renamed `createTRPCLikeClient` to `createAPIClient`, also exporting response types