### PR TITLE
Alliance endpoints

### DIFF
--- a/src/CustomEndpoints/Alliance.ts
+++ b/src/CustomEndpoints/Alliance.ts
@@ -1,0 +1,71 @@
+export type AllianceGetByIdInput = {
+	allianceId: string;
+};
+
+export type AllianceGetByIdsInput = {
+	ids: string[];
+};
+
+export type AllianceGetManyPaginatedInput = {
+	limit?: number;
+	cursor?: string;
+};
+
+export interface AllianceRankingEntry {
+	value: number;
+	rank: number;
+	tier: string;
+}
+
+export interface AllianceRankings {
+	allianceInitialDevelopment: AllianceRankingEntry;
+	allianceDevelopment: AllianceRankingEntry;
+	allianceWeeklyDamages: AllianceRankingEntry;
+	allianceDamages: AllianceRankingEntry;
+	alliancePopulation: AllianceRankingEntry;
+	allianceWeeklyDamagesPerCitizen: AllianceRankingEntry;
+}
+
+export interface AllianceMemberCountry {
+	country: string;
+	coreDevelopment: number;
+	averageDevelopment: number;
+	suspended: boolean;
+}
+
+export type Alliance = {
+	_id: string;
+	name: string;
+	scheme: string;
+	mapAccent: string;
+	leader: string;
+	memberCountries: AllianceMemberCountry[];
+	currentDevelopment: number;
+	coreDevelopment: number;
+	averageDevelopment: number;
+	createdAt: string;
+	updatedAt: string;
+	__v: number;
+	rankings: AllianceRankings;
+	avatarUrl?: string;
+};
+
+export type AllianceGetManyPaginatedResponse = {
+	items: Alliance[];
+	nextCursor?: string;
+};
+
+export type AllianceCustomEndpoints = {
+	"alliance.getById": {
+		input: AllianceGetByIdInput;
+		output: Alliance;
+	};
+	"alliance.getByIds": {
+		input: AllianceGetByIdsInput;
+		output: Alliance[];
+	};
+	"alliance.getManyPaginated": {
+		input: AllianceGetManyPaginatedInput;
+		output: AllianceGetManyPaginatedResponse;
+	};
+};

--- a/src/CustomEndpoints/index.ts
+++ b/src/CustomEndpoints/index.ts
@@ -1,4 +1,16 @@
 export type {
+	Alliance,
+	AllianceCustomEndpoints,
+	AllianceGetByIdInput,
+	AllianceGetByIdsInput,
+	AllianceGetManyPaginatedInput,
+	AllianceGetManyPaginatedResponse,
+	AllianceMemberCountry,
+	AllianceRankingEntry,
+	AllianceRankings
+} from "./Alliance";
+
+export type {
 	PartyCustomEndpoints,
 	PartyEthics,
 	PartyGetByIdInput,
@@ -78,6 +90,7 @@ export type {
 	TournamentRegistered
 } from "./Tournament";
 
+import type { AllianceCustomEndpoints } from "./Alliance";
 import type { CompanyCustomEndpoints } from "./Company";
 import type { DonationCustomEndpoints } from "./Donation";
 import type { ElectionCustomEndpoints } from "./Election";
@@ -90,7 +103,8 @@ import type { WorkOfferCustomEndpoints } from "./WorkOffer";
 import type { TournamentCustomEndpoints } from "./Tournament";
 
 export type WarEraCustomEndpoints =
-	PartyCustomEndpoints
+	AllianceCustomEndpoints
+	& PartyCustomEndpoints
 	& CompanyCustomEndpoints
 	& DonationCustomEndpoints
 	& ElectionCustomEndpoints

--- a/src/api/warera-openapi.d.ts
+++ b/src/api/warera-openapi.d.ts
@@ -735,7 +735,7 @@ export interface paths {
         put?: never;
         /**
          * Get battle orders
-         * @description Retrieves active battle orders for a specific battle and side
+         * @description Retrieves active battle orders for a specific battle and side. Order text is only included for citizens of the ordering country / members of the ordering MU.
          */
         post: operations["battleOrder.getByBattle"];
         delete?: never;
@@ -936,7 +936,7 @@ export interface operations {
                     /** @description Filter events by country ID */
                     countryId?: string;
                     /** @description Filter events by event types */
-                    eventTypes?: ("warDeclared" | "peace_agreement" | "battleOpened" | "battleEnded" | "newPresident" | "regionTransfer" | "peaceMade" | "countryMoneyTransfer" | "depositDiscovered" | "depositDepleted" | "systemRevolt" | "bankruptcy" | "allianceFormed" | "allianceBroken" | "regionLiberated" | "strategicResourcesReshuffled" | "resistanceIncreased" | "resistanceDecreased" | "revolutionStarted" | "revolutionEnded" | "financedRevolt")[];
+                    eventTypes?: ("warDeclared" | "peace_agreement" | "battleOpened" | "battleEnded" | "newPresident" | "regionTransfer" | "peaceMade" | "countryMoneyTransfer" | "depositDiscovered" | "depositDepleted" | "systemRevolt" | "bankruptcy" | "allianceFormed" | "allianceBroken" | "allianceMemberJoined" | "allianceMemberLeft" | "allianceMemberExcluded" | "defensivePactFormed" | "defensivePactBroken" | "regionLiberated" | "strategicResourcesReshuffled" | "resistanceIncreased" | "resistanceDecreased" | "revolutionStarted" | "revolutionEnded" | "financedRevolt")[];
                 };
             };
         };
@@ -1194,6 +1194,13 @@ export interface operations {
                      * @enum {string}
                      */
                     side: "attacker" | "defender" | "merged";
+                    /**
+                     * @description Number of ranking entries per page
+                     * @default 20
+                     */
+                    limit?: number;
+                    /** @description Cursor to fetch the next page of entries */
+                    cursor?: string;
                 };
             };
         };
@@ -1342,6 +1349,7 @@ export interface operations {
                     limit?: number;
                     energy?: number;
                     production?: number;
+                    level?: number;
                     citizenship?: string;
                 };
             };
@@ -1369,7 +1377,7 @@ export interface operations {
                      * @description The type of ranking to retrieve
                      * @enum {string}
                      */
-                    rankingType: "weeklyCountryDamages" | "weeklyCountryDamagesPerCitizen" | "countryRegionDiff" | "countryDevelopment" | "countryActivePopulation" | "countryDamages" | "countryWealth" | "countryProductionBonus" | "countryBounty" | "weeklyUserDamages" | "userDamages" | "userWealth" | "userLevel" | "userReferrals" | "userSubscribers" | "userTerrain" | "userPremiumMonths" | "userPremiumGifts" | "userCasesOpened" | "userGemsPurchased" | "userBounty" | "muWeeklyDamages" | "muDamages" | "muTerrain" | "muWealth" | "muBounty" | "muReputation";
+                    rankingType: "weeklyCountryDamages" | "weeklyCountryDamagesPerCitizen" | "countryRegionDiff" | "countryDevelopment" | "countryActivePopulation" | "countryDamages" | "countryWealth" | "countryProductionBonus" | "countryBounty" | "weeklyUserDamages" | "userDamages" | "userWealth" | "userLevel" | "userReferrals" | "userSubscribers" | "userTerrain" | "userPremiumMonths" | "userPremiumGifts" | "userCasesOpened" | "userGemsPurchased" | "userBounty" | "muWeeklyDamages" | "muDamages" | "muTerrain" | "muWealth" | "muBounty" | "muReputation" | "allianceInitialDevelopment" | "allianceDevelopment" | "allianceWeeklyDamages" | "allianceDamages" | "alliancePopulation" | "allianceWeeklyDamagesPerCitizen";
                 };
             };
         };
@@ -1689,7 +1697,7 @@ export interface operations {
                     /** @description The item code to get transactions for */
                     itemCode?: string;
                     /** @description The type of transactions to get */
-                    transactionType?: ("applicationFee" | "trading" | "itemMarket" | "wage" | "donation" | "articleTip" | "openCase" | "craftItem" | "dismantleItem" | "battleLoot") | ("applicationFee" | "trading" | "itemMarket" | "wage" | "donation" | "articleTip" | "openCase" | "craftItem" | "dismantleItem" | "battleLoot")[];
+                    transactionType?: ("applicationFee" | "trading" | "itemMarket" | "wage" | "donation" | "articleTip" | "openCase" | "craftItem" | "dismantleItem" | "battleLoot" | "countryMoneyTransfer") | ("applicationFee" | "trading" | "itemMarket" | "wage" | "donation" | "articleTip" | "openCase" | "craftItem" | "dismantleItem" | "battleLoot" | "countryMoneyTransfer")[];
                 };
             };
         };

--- a/tests/test-custom-endpoints.ts
+++ b/tests/test-custom-endpoints.ts
@@ -91,6 +91,16 @@ async function getTournamentTeamId(): Promise<string> {
 	return cachedTournamentTeamId;
 }
 
+let cachedAllianceId: string | undefined;
+async function getAllianceId(): Promise<string> {
+	if (cachedAllianceId) return cachedAllianceId;
+	const alliances = await client.alliance.getManyPaginated({ limit: 100 });
+	const allianceId = alliances.items?.[0]?._id;
+	assert(allianceId, "expected at least one alliance to test alliance endpoints");
+	cachedAllianceId = allianceId;
+	return cachedAllianceId;
+}
+
 const tests: EndpointTest[] = [
 	{
 		name: "company.getProductionBonus",
@@ -276,6 +286,38 @@ const tests: EndpointTest[] = [
 			assert(typeof value.tournament === "string", "expected string tournament");
 			assert(Array.isArray(value.participants), "expected participants array");
 			console.log("Received tournament team response:", value);
+		},
+	},
+	{
+		name: "alliance.getManyPaginated",
+		run: () => client.alliance.getManyPaginated({ limit: 100 }),
+		validate: (value) => {
+			assert(Array.isArray(value.items), "expected items array");
+			assert(value.nextCursor === undefined || typeof value.nextCursor === "string", "expected optional string nextCursor");
+			console.log(`Received ${value.items.length} alliances`);
+		},
+	},
+	{
+		name: "alliance.getById",
+		run: async () => client.alliance.getById({ allianceId: await getAllianceId() }),
+		validate: (value) => {
+			assert(isObject(value), "expected object response");
+			assert(typeof value._id === "string", "expected string _id");
+			assert(typeof value.name === "string", "expected string name");
+			assert(typeof value.leader === "string", "expected string leader");
+			assert(Array.isArray(value.memberCountries), "expected memberCountries array");
+			assert(isObject(value.rankings), "expected rankings object");
+			console.log("Received alliance by ID response:", value);
+		},
+	},
+	{
+		name: "alliance.getByIds",
+		run: async () => client.alliance.getByIds({ ids: [await getAllianceId()] }),
+		validate: (value) => {
+			assert(Array.isArray(value), "expected array response");
+			assert(value.length > 0, "expected at least one alliance");
+			assert(typeof value[0]._id === "string", "expected string _id on first alliance");
+			console.log(`Received ${value.length} alliances by IDs`);
 		},
 	},
 ];


### PR DESCRIPTION
Adds typed support for the new alliance endpoints (`getById`, `getByIds`, `getManyPaginated`), plus tests.

Note: `allianceLaw.*` is excluded (the server rejects API-token auth for it). Second commit is a clean `npm run openapi` regen picking up the new event/ranking enums.

Generated by Claude AI. I checked and seems consistent with the established conventions.